### PR TITLE
fix: limit the regions to be deployed

### DIFF
--- a/source/src/molecular-unfolding/cdk/stack-main.ts
+++ b/source/src/molecular-unfolding/cdk/stack-main.ts
@@ -7,6 +7,7 @@ import {
   Fn,
   RemovalPolicy,
   CfnOutput,
+  CfnRule
 } from 'aws-cdk-lib';
 
 
@@ -49,6 +50,13 @@ export class MainStack extends SolutionStack {
     super(scope, id, props);
     this.setDescription(DESCRIPTION);
     const stackName = this.stackName.replace(/[^a-zA-Z0-9_]+/, '').toLocaleLowerCase();
+
+    new CfnRule(this, 'deploymentRegionRules', {
+      'assertions': [{
+        'assert': Fn.conditionContains(['us-west-2', 'us-east-1'], this.region),
+        'assertDescription': 'deployment regions'
+      }]
+    });
 
     const prefix = 'molecular-unfolding';
 

--- a/source/src/molecular-unfolding/cdk/stack-main.ts
+++ b/source/src/molecular-unfolding/cdk/stack-main.ts
@@ -7,7 +7,7 @@ import {
   Fn,
   RemovalPolicy,
   CfnOutput,
-  CfnRule
+  CfnRule,
 } from 'aws-cdk-lib';
 
 
@@ -51,11 +51,12 @@ export class MainStack extends SolutionStack {
     this.setDescription(DESCRIPTION);
     const stackName = this.stackName.replace(/[^a-zA-Z0-9_]+/, '').toLocaleLowerCase();
 
-    new CfnRule(this, 'deploymentRegionRules', {
-      'assertions': [{
-        'assert': Fn.conditionContains(['us-west-2', 'us-east-1'], this.region),
-        'assertDescription': 'deployment regions'
-      }]
+    const supportRegions = ['us-west-2', 'us-east-1'];
+    new CfnRule(this, 'SupportedRegionsRule', {
+      assertions: [{
+        assert: Fn.conditionContains(supportRegions, this.region),
+        assertDescription: 'supported regions are ' + supportRegions.join(', '),
+      }],
     });
 
     const prefix = 'molecular-unfolding';

--- a/source/test/main.test.ts
+++ b/source/test/main.test.ts
@@ -249,6 +249,22 @@ test('CreateEventRuleFunc has the right policy', () => {
 
 });
 
+test('SupportedRegionsRule config correctly', () => {
+  const app = new App();
+  const stack = new MainStack(app, 'test');
+  const template = Template.fromStack(stack);
+
+  const supportedRegions = template.toJSON().Rules.SupportedRegionsRule.Assertions;
+  expect(supportedRegions).toEqual(
+    [
+      {
+        Assert: { 'Fn::Contains': [['us-west-2', 'us-east-1'], { Ref: 'AWS::Region' }] },
+        AssertDescription: 'supported regions are us-west-2, us-east-1',
+      },
+    ],
+  );
+
+});
 
 test('CreateEventRuleFuncServiceRole has CrossEventRegionCondition', () => {
   const app = new App();


### PR DESCRIPTION
closes #44: limit the regions to be deployed

*Description of changes:*
- add CfnRule to the deployment template

